### PR TITLE
fix: Correct company name and add auto-delete branch policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Purpos3 Engineering Best Practices
+# Purpose Engineering Best Practices
 
-This repository contains the official guidelines and best practices for software development at Purpos3. Our primary goal is to **avoid human error** by establishing clear, consistent, and automated workflows.
+This repository contains the official guidelines and best practices for software development at Purpose. Our primary goal is to **avoid human error** by establishing clear, consistent, and automated workflows.
 
 ## Guiding Principle: Keep it Clean and Simple
 
@@ -23,6 +23,13 @@ All pull requests (PRs) targeting the `main` branch **must** be squash merged. T
 Each feature branch should be created for a single, specific purpose and result in exactly one pull request.
 
 *   **Process:** Once the pull request is merged, the feature branch is automatically closed and should be deleted. This prevents branch proliferation and confusion.
+
+### 3. Auto-Delete Head Branches
+
+All repositories **must** have the "Automatically delete head branches" setting enabled in GitHub.
+
+*   **How to enable:** Go to Settings → General → Pull Requests → Check "Automatically delete head branches"
+*   **Why?** This automatically cleans up feature branches after PRs are merged, reducing manual overhead and keeping the repository tidy. Deleted branches can still be restored if needed.
 
 ---
 


### PR DESCRIPTION
## Summary
- Corrects company name from "Purpos3" to "Purpose" throughout the document
- Adds requirement for auto-delete head branches setting in all repositories
- Includes step-by-step instructions for enabling the setting in GitHub

## Test plan
- [x] Verify all instances of company name are corrected
- [x] Confirm new auto-delete section is clear and actionable
- [x] Test that formatting renders properly

This ensures consistency in branding and adds an important automation requirement to reduce manual branch cleanup overhead.